### PR TITLE
Fix error and warnings when compiling with clang 3.1

### DIFF
--- a/src/data/userinfo.h
+++ b/src/data/userinfo.h
@@ -27,6 +27,7 @@ struct UserInfo
 	UserInfo(UserInfo &uInfo);
 	UserInfo(wxString &username, wxString &password, 
 		bool rememberUsername, bool rememberPassword);
+	UserInfo(const UserInfo &) = default;
 	
 	wxString username;
 	wxString password;

--- a/src/gui/modeditwindow.cpp
+++ b/src/gui/modeditwindow.cpp
@@ -501,8 +501,9 @@ void ModEditWindow::OnMoveJarModDown(wxCommandEvent &event)
 	
 	wxArrayInt indices = jarModList->GetSelectedItems();
 	ModList *mods= m_inst->GetModList();
-	for (size_t i = indices.GetCount() - 1; i >= 0; --i)
+	for (size_t i = indices.GetCount(); i > 0;)
 	{
+		--i; // Fixes faulty comparison i>=0 on unsigned i above
 		if ((size_t)indices[i] + 1 >= mods->size())
 			continue;
 		

--- a/src/md5/md5.cpp
+++ b/src/md5/md5.cpp
@@ -135,7 +135,7 @@ void MD5Final(unsigned char digest[16], MD5Context *ctx)
     MD5Transform(ctx->buf, (uint32_t *) ctx->in);
     byteReverse((unsigned char *) ctx->buf, 4);
     memcpy(digest, ctx->buf, 16);
-    memset(ctx, 0, sizeof(ctx));        /* In case it's sensitive */
+    memset(ctx, 0, sizeof(*ctx));        /* In case it's sensitive */
 }
 
 


### PR DESCRIPTION
I got an error about a lacking copy constructor in UserInfo (don't know why, but explicitly specifying it fixes that), and I fixed that along with a couple of warnings while I was at it.
