### PR TITLE
Command line launching, download meter sanity check, 503 message

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -166,6 +166,9 @@ MainWindow::MainWindow(void)
 		InitAdvancedGUI(box);
 		break;
 	}
+
+	launchInstance = _("");
+
 	CenterOnScreen();
 }
 
@@ -188,6 +191,23 @@ void MainWindow::OnStartup()
 	{
 		CheckUpdateTask *task = new CheckUpdateTask();
 		StartTask(task,TASK_BACKGROUND);
+	}
+
+	if(!launchInstance.empty())
+	{
+		m_currentInstance = GetLinkedListByName(launchInstance);
+
+		if(m_currentInstance == nullptr)
+		{
+			wxString output = _("Couldn't find the instance you tried to load: ");
+			output.append(launchInstance);
+			output.append(_(". Make sure it exists!"));
+			wxLogError(output);
+		}
+		else
+		{
+			ShowLoginDlg(_(""));
+		}
 	}
 }
 
@@ -423,6 +443,19 @@ Instance* MainWindow::GetLinkedInst(int id)
 	if(id == -1)
 		return nullptr;
 	return instItems[id];
+}
+
+Instance* MainWindow::GetLinkedListByName(wxString instanceName)
+{
+	for(std::vector<Instance*>::iterator it = instItems.begin(); it != instItems.end(); ++it)
+	{
+		if((*it)->GetName().CompareTo(instanceName) == 0)
+		{
+			return (*it);
+		}
+	}
+
+	return nullptr;
 }
 
 bool MainWindow::GetNewInstName(wxString *instName, wxString *instDirName, const wxString title)

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -752,6 +752,13 @@ void MainWindow::ShowLoginDlg(wxString errorMsg)
 			OnLoginComplete(event);
 		}
 	}
+	else if(response == wxID_CANCEL)
+	{
+		if(!launchInstance.empty())
+		{
+			this->Destroy();
+		}
+	}
 }
 
 void MainWindow::OnLoginComplete(LoginCompleteEvent& event)

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -195,7 +195,7 @@ void MainWindow::OnStartup()
 
 	if(!launchInstance.empty())
 	{
-		m_currentInstance = GetLinkedListByName(launchInstance);
+		m_currentInstance = GetLinkedInstByName(launchInstance);
 
 		if(m_currentInstance == nullptr)
 		{
@@ -445,7 +445,7 @@ Instance* MainWindow::GetLinkedInst(int id)
 	return instItems[id];
 }
 
-Instance* MainWindow::GetLinkedListByName(wxString instanceName)
+Instance* MainWindow::GetLinkedInstByName(wxString instanceName)
 {
 	for(std::vector<Instance*>::iterator it = instItems.begin(); it != instItems.end(); ++it)
 	{

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -195,7 +195,9 @@ void MainWindow::OnStartup()
 
 	if(!launchInstance.empty())
 	{
-		m_currentInstance = GetLinkedInstByName(launchInstance);
+		wxFileName instanceDir = settings->GetInstDir();
+		instanceDir.AppendDir(launchInstance);
+		m_currentInstance = Instance::LoadInstance(instanceDir);
 
 		if(m_currentInstance == nullptr)
 		{
@@ -443,19 +445,6 @@ Instance* MainWindow::GetLinkedInst(int id)
 	if(id == -1)
 		return nullptr;
 	return instItems[id];
-}
-
-Instance* MainWindow::GetLinkedInstByName(wxString instanceName)
-{
-	for(std::vector<Instance*>::iterator it = instItems.begin(); it != instItems.end(); ++it)
-	{
-		if((*it)->GetName().CompareTo(instanceName) == 0)
-		{
-			return (*it);
-		}
-	}
-
-	return nullptr;
 }
 
 bool MainWindow::GetNewInstName(wxString *instName, wxString *instDirName, const wxString title)

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -126,7 +126,6 @@ protected:
 	GUIMode m_guiMode;
 
 	Instance* GetLinkedInst(int id);
-	Instance* GetLinkedInstByName(wxString instanceName);
 
 	bool DeleteSelectedInstance();
 

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -115,6 +115,8 @@ public:
 	
 	void OnNewInstance(wxCommandEvent& event);
 	void OnImportMCFolder(wxCommandEvent& event);
+
+	wxString launchInstance;
 	
 	DECLARE_EVENT_TABLE()
 
@@ -124,6 +126,7 @@ protected:
 	GUIMode m_guiMode;
 
 	Instance* GetLinkedInst(int id);
+	Instance* GetLinkedListByName(wxString instanceName);
 
 	bool DeleteSelectedInstance();
 

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -126,7 +126,7 @@ protected:
 	GUIMode m_guiMode;
 
 	Instance* GetLinkedInst(int id);
-	Instance* GetLinkedListByName(wxString instanceName);
+	Instance* GetLinkedInstByName(wxString instanceName);
 
 	bool DeleteSelectedInstance();
 

--- a/src/multimc.cpp
+++ b/src/multimc.cpp
@@ -90,6 +90,15 @@ bool MultiMC::OnInit()
 			return true;
 		}
 
+	case START_LAUNCH_INSTANCE:
+		{
+			MainWindow *mainWin = new MainWindow();
+			mainWin->Show();
+			mainWin->launchInstance = launchInstance;
+			mainWin->OnStartup();
+			return true;
+		}
+
 	case START_INSTALL_UPDATE:
 		InstallUpdate();
 		return false;
@@ -106,12 +115,18 @@ void MultiMC::OnInitCmdLine(wxCmdLineParser &parser)
 
 bool MultiMC::OnCmdLineParsed(wxCmdLineParser& parser)
 {
-	wxString fileToUpdate;
-	if (parser.Found(_("u"), &fileToUpdate))
+	wxString parsedOption;
+	if (parser.Found(_("u"), &parsedOption))
 	{
 		thisFileName = wxStandardPaths::Get().GetExecutablePath();
-		updateTarget = fileToUpdate;
+		updateTarget = parsedOption;
 		startMode = START_INSTALL_UPDATE;
+		return true;
+	}
+	else if(parser.Found(_("l"), &parsedOption))
+	{
+		launchInstance = parsedOption;
+		startMode = START_LAUNCH_INSTANCE;
 		return true;
 	}
 	return true;

--- a/src/multimc.h
+++ b/src/multimc.h
@@ -27,6 +27,7 @@ protected:
 
 	wxString thisFileName;
 	wxString updateTarget;
+	wxString launchInstance;
 	
 	void InstallUpdate();
 	void YieldSleep(int secs);
@@ -38,6 +39,9 @@ protected:
 
 		// Installs updates and exits.
 		START_INSTALL_UPDATE,
+
+		// Launches an instance on start.
+		START_LAUNCH_INSTANCE
 	} startMode;
 };
 
@@ -47,6 +51,9 @@ const wxCmdLineEntryDesc cmdLineDesc[] =
 		wxCMD_LINE_VAL_NONE, wxCMD_LINE_OPTION_HELP },
 
 	{ wxCMD_LINE_OPTION, _("u"), _("update"), _("replaces the given file with the running executable"),
+		wxCMD_LINE_VAL_STRING },
+
+	{ wxCMD_LINE_OPTION, _("l"), _("launch"), _("tries to launch the given instance"),
 		wxCMD_LINE_VAL_STRING },
 
 	{ wxCMD_LINE_NONE }

--- a/src/tasks/filedownloadtask.cpp
+++ b/src/tasks/filedownloadtask.cpp
@@ -64,9 +64,20 @@ wxThread::ExitCode FileDownloadTask::TaskStart()
 	{
 		outStream.Write(buffer, size);
 		downloadedSize += outStream.LastWrite();
-		SetProgress(((double)downloadedSize / (double)downloadSize) * 100);
+		int progress = ((double)downloadedSize / (double)downloadSize) * 100;
+		SetProgress(progress);
 
-		wxString sDownloadedSize = wxString::Format(wxT("%.0f"), (float)(downloadedSize / 1000));
+		wxString sDownloadedSize = _("???");
+
+		if(progress >= 100 || downloadedSize > downloadSize)
+		{
+			sDownloadedSize = wxString::Format(wxT("%.0f"), (float)(downloadSize / 1000));
+		}
+		else
+		{
+			sDownloadedSize = wxString::Format(wxT("%.0f"), (float)(downloadedSize / 1000));
+		}
+
 		wxString sDownloadSize = wxString::Format(wxT("%.0f"), (float)(downloadSize / 1000));
 		SetStatus(wxString::Format(_("Downloading... (%skB/%skB)"), sDownloadedSize.c_str(), sDownloadSize.c_str()));
 

--- a/src/tasks/logintask.cpp
+++ b/src/tasks/logintask.cpp
@@ -81,7 +81,7 @@ wxThread::ExitCode LoginTask::TaskStart()
 	}
 	else if (response == 503)
 	{
-		OnLoginComplete(wxString::Format(_("HTTP error 503 - the login servers are currently unavailable.")));
+		OnLoginComplete(wxString::Format(_("503 - login servers unavailable. Check help.mojang.com!")));
 	}
 	else
 	{

--- a/src/tasks/logintask.cpp
+++ b/src/tasks/logintask.cpp
@@ -79,6 +79,10 @@ wxThread::ExitCode LoginTask::TaskStart()
 		OnLoginComplete(outString);
 		return (void *)1;
 	}
+	else if (response == 503)
+	{
+		OnLoginComplete(wxString::Format(_("HTTP error 503 - the login servers are currently unavailable.")));
+	}
 	else
 	{
 		OnLoginComplete(wxString::Format(_("Unknown HTTP error %i occurred."), response));


### PR DESCRIPTION
Window should close after instance closing if launched with the command line - I asked peterix to take a look once this was pulled.

Also added HTTP 503 case for when the login servers are down, included help.mojang.com
