### PR TITLE
Use platform specific setting path for JavaPath in instance settings

### DIFF
--- a/src/data/instance.h
+++ b/src/data/instance.h
@@ -143,7 +143,7 @@ public:
 	DEFINE_IGNORED_SETTING(InstSortMode, InstSortMode);
 
 	// and these are overrides
-	DEFINE_OVERRIDDEN_SETTING_ADVANCED(JavaPath, "JPath", wxString);
+	DEFINE_OVERRIDDEN_SETTING_ADVANCED(JavaPath, JPATH_FIELD_NAME, wxString);
 	DEFINE_OVERRIDDEN_SETTING(JvmArgs, wxString);
 
 	DEFINE_OVERRIDDEN_SETTING_ADVANCED(MaxMemAlloc, "MaxMemoryAlloc", int);


### PR DESCRIPTION
The key used to store the java path setting in instance configurations uses the same platform specific name as the overall application settings.  However, the instance data object was looking at a generic key.  This meant you could set an instance specific java path but MultiMC wouldn't use it, wouldn't show it when re-opening the instance settings, but would save it to the instance configuration.  This change makes the dialog show the custom path, use it when launching MC, and save/load it properly.
