### PR TITLE
Check for the proper id to trigger save-to-file

### DIFF
--- a/src/gui/consolewindow.cpp
+++ b/src/gui/consolewindow.cpp
@@ -688,7 +688,7 @@ void InstConsoleWindow::OnGenReportClicked(wxCommandEvent& event)
 		}
 		delete task;
 	}
-	else if (response == id_pastebin) // Save to file
+	else if (response == id_file) // Save to file
 	{
 		wxFileDialog saveReportDlg(this, _("Save Crash Report"), wxGetCwd(), 
 			wxDateTime::Now().Format("MultiMC_Report_%m-%d-%Y_%H-%M-%S.txt"), 


### PR DESCRIPTION
The crash report dialog had the button ids wrong for the save-to-file action.
