### PR TITLE
Changes for new GCC and wxWidgets 2.9.4

### DIFF
--- a/src/data/mcprocess.cpp
+++ b/src/data/mcprocess.cpp
@@ -58,7 +58,7 @@ wxProcess* MinecraftProcess::Launch ( Instance* source, InstConsoleWindow* paren
 	if(env.env["XMODIFIERS"].Contains(ibus))
 	{
 		wxString source = env.env["XMODIFIERS"];
-		int start = source.Index(ibus);
+		int start = source.Index(ibus.GetData());
 		env.env["XMODIFIERS"] = source.Left(start) + source.Right(source.length()-start-ibus.length());
 		parent->AppendMessage(wxString::Format(_("Fixed XMODIFIERS: was \"%s\", now \"%s\""), source, env.env["XMODIFIERS"]));
 	}

--- a/src/data/mod.h
+++ b/src/data/mod.h
@@ -49,7 +49,7 @@ public:
 	ModType GetModType() const;
 
 	
-	// True if this mod is a zip file. Deprecated, use 
+	// True if this mod is a zip file. Deprecated, use GetModType and compare
 	wxDEPRECATED(bool IsZipMod() const);
 
 	bool operator ==(const Mod &other) const;

--- a/src/data/modlist.cpp
+++ b/src/data/modlist.cpp
@@ -149,9 +149,9 @@ void ModList::LoadFromFile(const wxString& file)
 		return;
 
 	wxFFileInputStream inputStream(file);
-	wxStringList modListFile = ReadAllLines(inputStream);
+	wxArrayString modListFile = ReadAllLines(inputStream);
 
-	for (wxStringList::iterator iter = modListFile.begin(); iter != modListFile.end(); iter++)
+	for (wxArrayString::iterator iter = modListFile.begin(); iter != modListFile.end(); iter++)
 	{
 		// Normalize the path to the instMods dir.
 		wxFileName modFile(*iter);

--- a/src/multimc.h
+++ b/src/multimc.h
@@ -89,19 +89,19 @@ protected:
 
 const wxCmdLineEntryDesc cmdLineDesc[] = 
 {
-	{ wxCMD_LINE_SWITCH, "h", "help", _("displays help on command line parameters"), 
+	{ wxCMD_LINE_SWITCH, "h", "help", "displays help on command line parameters", 
 		wxCMD_LINE_VAL_NONE, wxCMD_LINE_OPTION_HELP },
 
-	{ wxCMD_LINE_OPTION, "u", "update", _("replaces the given file with the running executable"),
+	{ wxCMD_LINE_OPTION, "u", "update", "replaces the given file with the running executable",
 		wxCMD_LINE_VAL_STRING },
 
-	{ wxCMD_LINE_SWITCH, "U", "quietupdate", _("doesn't restart MultiMC after installing updates"),
+	{ wxCMD_LINE_SWITCH, "U", "quietupdate", "doesn't restart MultiMC after installing updates",
 		wxCMD_LINE_VAL_NONE },
 
-	{ wxCMD_LINE_OPTION, "l", "launch", _("tries to launch the given instance"),
+	{ wxCMD_LINE_OPTION, "l", "launch", "tries to launch the given instance",
 		wxCMD_LINE_VAL_STRING },
 	
-	{ wxCMD_LINE_OPTION, "d", "dir", _("use the supplied directory as MultiMC root instead of the binary location (use '.' for current)"),
+	{ wxCMD_LINE_OPTION, "d", "dir", "use the supplied directory as MultiMC root instead of the binary location (use '.' for current)",
 		wxCMD_LINE_VAL_STRING },
 
 	{ wxCMD_LINE_NONE }

--- a/src/tasks/moddertask.cpp
+++ b/src/tasks/moddertask.cpp
@@ -78,11 +78,11 @@ wxThread::ExitCode ModderTask::TaskStart()
 	{
 		wxFileName modFileName = iter->GetFileName();
 		SetStatus(_("Installing mods - Adding ") + modFileName.GetFullName());
-		if (iter->IsZipMod())
+		if (iter->GetModType() == Mod::ModType::MOD_ZIPFILE)
 		{
 			wxFFileInputStream modStream(modFileName.GetFullPath());
 			wxZipInputStream zipStream(modStream);
-			std::auto_ptr<wxZipEntry> entry;
+			std::unique_ptr<wxZipEntry> entry;
 			while (entry.reset(zipStream.GetNextEntry()), entry.get() != NULL)
 			{
 				if (entry->IsDir())

--- a/src/utils/apputils.cpp
+++ b/src/utils/apputils.cpp
@@ -351,7 +351,7 @@ bool CreateShortcut(wxString path, wxString name, wxString dest, wxString args, 
 
 	desktopfile.close();
 
-	chmod(path, 0755);
+	chmod(path.c_str(), 0755);
 
 	return true;
 }

--- a/src/utils/datautils.cpp
+++ b/src/utils/datautils.cpp
@@ -38,11 +38,11 @@ wxString ReadAllText(wxInputStream& input)
 	return outString;
 }
 
-wxStringList ReadAllLines(wxInputStream& input)
+wxArrayString ReadAllLines(wxInputStream& input)
 {
 	wxString text = ReadAllText(input);
 	wxStringTokenizer tokenizer(text, "\r\n");
-	wxStringList lineList;
+	wxArrayString lineList;
 	while (tokenizer.HasMoreTokens())
 	{
 		lineList.Add(tokenizer.NextToken());

--- a/src/utils/datautils.h
+++ b/src/utils/datautils.h
@@ -57,6 +57,6 @@ size_t Find(InputIterator first, InputIterator last, Predicate pred)
 }
 
 wxString ReadAllText(wxInputStream &input);
-wxStringList ReadAllLines(wxInputStream &input);
+wxArrayString ReadAllLines(wxInputStream &input);
 
 void WriteAllText(wxOutputStream &output, wxString text);

--- a/src/utils/fsutils.cpp
+++ b/src/utils/fsutils.cpp
@@ -158,7 +158,7 @@ bool RecursiveDelete(const wxString &path)
 void ExtractZipArchive(wxInputStream &stream, const wxString &dest)
 {
 	wxZipInputStream zipStream(stream);
-	std::auto_ptr<wxZipEntry> entry;
+	std::unique_ptr<wxZipEntry> entry;
 	while (entry.reset(zipStream.GetNextEntry()), entry.get() != NULL)
 	{
 		if (entry->IsDir())
@@ -191,7 +191,7 @@ void ExtractZipArchive(wxInputStream &stream, const wxString &dest)
 void TransferZipArchive(wxInputStream &stream, wxZipOutputStream &out)
 {
 	wxZipInputStream zipStream(stream);
-	std::auto_ptr<wxZipEntry> entry;
+	std::unique_ptr<wxZipEntry> entry;
 	while (entry.reset(zipStream.GetNextEntry()), entry.get() != NULL)
 	{
 		if (entry->IsDir())


### PR DESCRIPTION
Fixed several uses of deprecated classes/functions and a few other things that caused compiler errors on my system using
gcc (Ubuntu/Linaro 4.7.2-2ubuntu1) 4.7.2
wxwidgets 2.9.4
boost 1.53.0
